### PR TITLE
Add gatsby files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,7 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+
+#gatsby files
+.cache/
+public


### PR DESCRIPTION
This PR add gatsby files: `public` and `.cache` to `gitignore`

This prevent pushing the file to github repository